### PR TITLE
Added Endpoints for Fetching Pending Gym Profiles & User-Specific Gym…

### DIFF
--- a/SpringBoot_Backend/src/main/java/com/knowit/gymintellect/gym_intellect/controller/GymProfileController.java
+++ b/SpringBoot_Backend/src/main/java/com/knowit/gymintellect/gym_intellect/controller/GymProfileController.java
@@ -61,4 +61,18 @@ public class GymProfileController {
         gymProfileService.deleteGymProfile(id);
         return ResponseEntity.noContent().build();
     }
+
+    // New endpoint to fetch all pending gym profiles
+    @GetMapping("/pending")
+    public ResponseEntity<List<GymProfile>> getPendingGymProfiles() {
+        List<GymProfile> pendingProfiles = gymProfileService.getPendingGymProfiles();
+        return ResponseEntity.ok(pendingProfiles);
+    }
+    
+ // Endpoint to check if a gym profile is approved for a given owner
+    @GetMapping("/gym-profiles/{userId}")
+    @PreAuthorize("hasRole('GYM_OWNER')")
+    public List<GymProfile> getGymProfilesByUserIdentiy(@PathVariable Long userId) {
+        return gymProfileService.getGymProfilesByUserId(userId);
+    }
 }


### PR DESCRIPTION
This update introduces new API endpoints to enhance gym profile management by enabling retrieval of pending gym profiles and checking gym profiles linked to a specific gym owner.

**Changes Included:**

- Added /pending endpoint to fetch all gym profiles with a PENDING status.
- Created /gym-profiles/{userId} endpoint to retrieve gym profiles associated with a specific gym owner.
- Added @PreAuthorize("hasRole('GYM_OWNER')") to ensure only gym owners can access their profiles.

**Additional Notes:**

- The /pending endpoint helps the main admin review unapproved gym profiles.
- The /gym-profiles/{userId} endpoint allows gym owners to view their registered gyms.

Let me know if you'd like any modifications! 